### PR TITLE
Downgrade parity-db version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ kvdb-rocksdb = "0.19.0"
 libsecp256k1 = { version = "0.7.1", default-features = false }
 log = { version = "0.4.20", default-features = false }
 num_enum = { version = "0.6.1", default-features = false }
-parity-db = "0.4.10"
+parity-db = "0.4.9"
 parking_lot = "0.12.1"
 rlp = { version = "0.5.2", default-features = false }
 scale-codec = { package = "parity-scale-codec", version = "3.6.4", default-features = false, features = ["derive"] }


### PR DESCRIPTION
This will allow us to downgrade parity-db in monorepo to work around regression: https://github.com/paritytech/parity-db/issues/226